### PR TITLE
fix: adiciona step para gerar o cliente do prisma

### DIFF
--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -18,6 +18,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
       - name: Apply migrations on Dev
         run: npx prisma migrate deploy
         env:

--- a/.github/workflows/migrate-prod.yml
+++ b/.github/workflows/migrate-prod.yml
@@ -17,6 +17,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
       - name: Validate Schema
         run: npx prisma validate
         env:


### PR DESCRIPTION
Como a pasta `generated/prisma` foi adicionada no `.gitignore` (o que é certo, é melhor gerar do 0 toda vez) o workflow precisava do comando de gerar o cliente localizado nessa pasta:

```
      - name: Generate Prisma Client
        run: npx prisma generate
```



closes #20 