### PR TITLE
feat: altera veiculo_id para nullable na tabela solicitacao

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -946,8 +947,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
@@ -1195,6 +1195,7 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1438,6 +1439,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.4.2",
         "@prisma/dev": "0.20.0",
@@ -1599,8 +1601,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/seq-queue": {
       "version": "0.0.5",
@@ -1697,6 +1698,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/prisma/migrations/20260317012328_veiculo_id_nullable/migration.sql
+++ b/prisma/migrations/20260317012328_veiculo_id_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `solicitacao` MODIFY `veiculo_id` INTEGER NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,7 +139,7 @@ model Veiculo {
 model Solicitacao {
   id                 Int                 @id @default(autoincrement())
   usuarioId          Int                 @map("usuario_id")
-  veiculoId          Int                 @map("veiculo_id")
+  veiculoId          Int?                 @map("veiculo_id")
   servicoId          Int                 @map("servico_id")
   status             StatusSolicitacao   @default(recebido)
   observacaoCliente  String?             @map("observacao_cliente") @db.Text
@@ -148,7 +148,7 @@ model Solicitacao {
   dataConclusao      DateTime?           @map("data_conclusao")
 
   usuario            Usuario             @relation(fields: [usuarioId], references: [id], onDelete: Cascade)
-  veiculo            Veiculo             @relation(fields: [veiculoId], references: [id], onDelete: Cascade)
+  veiculo            Veiculo?             @relation(fields: [veiculoId], references: [id], onDelete: Cascade)
   servico            Servico             @relation(fields: [servicoId], references: [id])
   documentos         DocumentoSolicitacao[]
 


### PR DESCRIPTION
Foi realizada uma alteração estrutural no banco de dados com o objetivo de permitir que o campo veiculo_id da tabela solicitacao aceite valores nulos.
Essa mudança foi necessária porque nem todos os tipos de serviço dependem de um veículo cadastrado, como por exemplo serviços relacionados apenas ao usuário, como renovação de CNH. Dessa forma, manter o campo como obrigatório impedia a criação de solicitações válidas para esses casos.

A modificação foi feita seguindo o fluxo padrão de versionamento de banco utilizando Prisma Migrations, conforme definido na estrutura do projeto.

Primeiramente, foi realizada a alteração no arquivo schema.prisma, tornando o campo veiculoId opcional, alterando seu tipo de Int para Int?.
Além disso, a relação com o model Veiculo também foi alterada para opcional, mudando de Veiculo para Veiculo?, garantindo consistência entre o campo da foreign key e a relação definida no Prisma.