### PR TITLE
feat: adiciona campo status em FAQ e tabela emails_enviados #36

### DIFF
--- a/prisma/migrations/20260320154547_adiciona_status_faq_e_tabela_emails/migration.sql
+++ b/prisma/migrations/20260320154547_adiciona_status_faq_e_tabela_emails/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE `FAQ` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `pergunta` VARCHAR(191) NOT NULL,
+    `resposta` VARCHAR(191) NOT NULL,
+    `status` BOOLEAN NOT NULL DEFAULT true,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `emails_enviados` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `nome_usuario` VARCHAR(255) NOT NULL,
+    `email_usuario` VARCHAR(255) NOT NULL,
+    `texto_digitado` TEXT NOT NULL,
+    `data_envio` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/migrations/20260322023734_corrige_faq_e_adiciona_assunto_emails/migration.sql
+++ b/prisma/migrations/20260322023734_corrige_faq_e_adiciona_assunto_emails/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the `FAQ` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `assunto` to the `emails_enviados` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `emails_enviados` ADD COLUMN `assunto` VARCHAR(255) NOT NULL;
+
+-- AlterTable
+ALTER TABLE `faq` ADD COLUMN `status` BOOLEAN NOT NULL DEFAULT true;
+
+-- DropTable
+DROP TABLE `FAQ`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -176,3 +176,18 @@ model DocumentoSolicitacao {
 
   @@map("documento_solicitacao")
 }
+
+model FAQ {
+  id       Int     @id @default(autoincrement())
+  pergunta String
+  resposta String
+  status   Boolean @default(true)  
+}
+
+model emails_enviados {
+  id             Int      @id @default(autoincrement())
+  nome_usuario   String   @db.VarChar(255)
+  email_usuario  String   @db.VarChar(255)
+  texto_digitado String   @db.Text
+  data_envio     DateTime @default(now())
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,7 @@ model Faq {
   id       Int     @id @default(autoincrement())
   pergunta String? @db.Text
   resposta String? @db.Text
+  status   Boolean @default(true)
 
   @@map("faq")
 }
@@ -177,17 +178,12 @@ model DocumentoSolicitacao {
   @@map("documento_solicitacao")
 }
 
-model FAQ {
-  id       Int     @id @default(autoincrement())
-  pergunta String
-  resposta String
-  status   Boolean @default(true)  
-}
 
 model emails_enviados {
   id             Int      @id @default(autoincrement())
   nome_usuario   String   @db.VarChar(255)
   email_usuario  String   @db.VarChar(255)
+  assunto        String   @db.VarChar(255) 
   texto_digitado String   @db.Text
   data_envio     DateTime @default(now())
 }


### PR DESCRIPTION
- Adicionado campo `status` (boolean) na tabela `FAQ` para ativar/desativar perguntas
- Criada tabela `emails_enviados` com os campos: id, nome_usuario, email_usuario, texto_digitado, data_envio