### PR TITLE
fix: corrige ordem dos steps de CI, ajusta schema do Prisma e melhora seed

### DIFF
--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -18,13 +18,15 @@ jobs:
 
       - run: npm ci
 
-      - name: Generate Prisma Client
-        run: npx prisma generate
-
       - name: Apply migrations on Dev
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: ${{secrets.DATABASE_URL_DEV}}
+          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_DEV }}
 
       - name: Seed Dev Database
         run: npx prisma db seed

--- a/.github/workflows/migrate-prod.yml
+++ b/.github/workflows/migrate-prod.yml
@@ -17,15 +17,17 @@ jobs:
 
       - run: npm ci
 
-      - name: Generate Prisma Client
-        run: npx prisma generate
-
       - name: Validate Schema
         run: npx prisma validate
         env:
-          DATABASE_URL: ${{secrets.DATABASE_URL_PROD}}
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
 
       - name: Apply migrations on Production
         run: npx prisma migrate deploy
         env:
-          DATABASE_URL: ${{secrets.DATABASE_URL_PROD}}
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Antes de iniciar qualquer modificação, é fundamental entender onde você est�
     2. Subir os Containers
     ```bash
     docker compose -f compose.dev.yml up --build -d
-
-    Nota: O container prisma-migration irá automaticamente instalar as dependências, gerar o Prisma Client, aplicar as migrations existentes e executar o script de seed para popular o banco.
     ```
+    > Nota: o arquivo `compose.dev.yml` sobe o banco de dados local **junto com** o container `prisma-migration`, que irá automaticamente instalar as dependências, gerar o Prisma Client, aplicar as migrations existentes e executar o script de seed para popular o banco.
+    
 --- 
 
 Para se conectar ao banco, utilize uma ferramenta de banco de dados como o `HeidiSQL`, `DataGrip`, `dBeaver` ou `MySQL Workbench`

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -21,7 +21,7 @@ services:
       retries: 10
 
   migration:
-    image: node:20-alpine
+    image: node:22-alpine
     container_name: prisma-migration
     depends_on:
       mysql:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,14 +94,14 @@ model Banner {
 }
 
 model Blog {
-  id             Int       @id @default(autoincrement())
-  titulo         String?   @db.VarChar(150)
-  conteudo       String?   @db.Text
-  dataPublicacao DateTime? @map("data_publicacao") @db.Date
-  urlImagem      String?   @map("url_imagem")
-  ativo          Boolean   @default(true)
-  olhoDoTexto String?  @map("olho_do_texto") 
-  categoria  CategoriaBlog  @default(Documentacao)
+  id             Int           @id @default(autoincrement())
+  titulo         String?       @db.VarChar(150)
+  conteudo       String?       @db.Text
+  dataPublicacao DateTime?     @map("data_publicacao") @db.Date
+  urlImagem      String?       @map("url_imagem")
+  ativo          Boolean       @default(true)
+  olhoDoTexto    String?       @map("olho_do_texto")
+  categoria      CategoriaBlog @default(Documentacao)
 
   @@map("blog")
 }
@@ -222,13 +222,15 @@ model DocumentoSolicitacao {
   @@map("documento_solicitacao")
 }
 
-model emails_enviados {
-  id             Int      @id @default(autoincrement())
-  nome_usuario   String   @db.VarChar(255)
-  email_usuario  String   @db.VarChar(255)
-  assunto        String   @db.VarChar(255)
-  texto_digitado String   @db.Text
-  data_envio     DateTime @default(now())
+model EmailsEnviados {
+  id            Int      @id @default(autoincrement())
+  nomeUsuario   String   @map("nome_usuario") @db.VarChar(255)
+  emailUsuario  String   @map("email_usuario") @db.VarChar(255)
+  assunto       String   @db.VarChar(255)
+  textoDigitado String   @map("texto_digitado") @db.Text
+  dataEnvio     DateTime @default(now()) @map("data_envio")
+
+  @@map("emails_enviados")
 }
 
 model Debito {
@@ -239,9 +241,9 @@ model Debito {
   status    StatusDebito @default(pendente)
   createdAt DateTime     @default(now()) @map("created_at")
 
-  pagamento      Pagamento?
-  debitoServicos DebitoServico?
-  debitoVeiculos DebitoVeiculo?
+  pagamento     Pagamento?
+  debitoServico DebitoServico?
+  debitoVeiculo DebitoVeiculo?
 
   @@map("debito")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -750,6 +750,7 @@ async function main() {
                 emailUsuario: email.emailUsuario,
                 assunto: email.assunto,
                 textoDigitado: email.textoDigitado,
+                dataEnvio: email.dataEnvio,
             },
             create: email,
         });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,11 +8,20 @@ import {
     StatusDebito,
     TipoPagamento,
     StatusParcela,
-    CategoriaBlog 
+    CategoriaBlog
 } from '../generated/prisma/client.js';
 import {PrismaMariaDb} from '@prisma/adapter-mariadb';
 
-const adapter = new PrismaMariaDb(process.env.DATABASE_URL!.replace('mysql://', 'mariadb://'));
+const rawDatabaseUrl = process.env.DATABASE_URL;
+if (!rawDatabaseUrl) {
+    throw new Error('DATABASE_URL não está definida. Defina a variável de ambiente DATABASE_URL antes de executar o seed.');
+}
+const databaseUrl = new URL(rawDatabaseUrl);
+if (databaseUrl.protocol === 'mysql:') {
+    databaseUrl.protocol = 'mariadb:';
+}
+const adapter = new PrismaMariaDb(databaseUrl.toString());
+
 const prisma = new PrismaClient({adapter});
 
 async function main() {
@@ -315,7 +324,7 @@ async function main() {
             olhoDoTexto: 'Evite surpresas na hora da transferência — confira a lista completa',
             categoria: CategoriaBlog.Documentacao
         },
-        
+
         {
             id: 4,
             titulo: 'Nova lei de trânsito 2026',

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,7 +8,7 @@ import {
     StatusDebito,
     TipoPagamento,
     StatusParcela,
-    CategoriaBlog
+    CategoriaBlog,
 } from '../generated/prisma/client.js';
 import {PrismaMariaDb} from '@prisma/adapter-mariadb';
 
@@ -304,7 +304,8 @@ async function main() {
             dataPublicacao: new Date('2026-01-10'),
             urlImagem: 'https://img.com/blog1.jpg',
             olhoDoTexto: 'Não pague multa por atraso — veja seu vencimento agora',
-            categoria: CategoriaBlog.Debitos
+            categoria: CategoriaBlog.Debitos,
+            ativo: true
         },
         {
             id: 2,
@@ -313,7 +314,8 @@ async function main() {
             dataPublicacao: new Date('2026-01-15'),
             urlImagem: 'https://img.com/blog2.jpg',
             olhoDoTexto: 'Sua multa pode ser cancelada — saiba como recorrer',
-            categoria: CategoriaBlog.Multas
+            categoria: CategoriaBlog.Multas,
+            ativo: false
         },
         {
             id: 3,
@@ -322,7 +324,8 @@ async function main() {
             dataPublicacao: new Date('2026-01-20'),
             urlImagem: 'https://img.com/blog3.jpg',
             olhoDoTexto: 'Evite surpresas na hora da transferência — confira a lista completa',
-            categoria: CategoriaBlog.Documentacao
+            categoria: CategoriaBlog.Documentacao,
+            ativo: true
         },
 
         {
@@ -332,7 +335,8 @@ async function main() {
             dataPublicacao: new Date('2026-02-01'),
             urlImagem: 'https://img.com/blog4.jpg',
             olhoDoTexto: 'As novas regras já valem — você está por dentro?',
-            categoria: CategoriaBlog.Legislacao
+            categoria: CategoriaBlog.Legislacao,
+            ativo: true
         },
         {
             id: 5,
@@ -341,13 +345,22 @@ async function main() {
             dataPublicacao: new Date('2026-02-10'),
             urlImagem: 'https://img.com/blog5.jpg',
             olhoDoTexto: 'Seu direito de dirigir depende desses cuidados',
-            categoria: CategoriaBlog.Condutor
+            categoria: CategoriaBlog.Condutor,
+            ativo: true
         },
     ];
     for (const p of posts) {
         await prisma.blog.upsert({
             where: {id: p.id},
-            update: {titulo: p.titulo, conteudo: p.conteudo, dataPublicacao: p.dataPublicacao},
+            update: {
+                titulo: p.titulo,
+                conteudo: p.conteudo,
+                dataPublicacao: p.dataPublicacao,
+                urlImagem: p.urlImagem,
+                olhoDoTexto: p.olhoDoTexto,
+                categoria: p.categoria,
+                ativo: p.ativo,
+            },
             create: p,
         });
     }
@@ -706,6 +719,43 @@ async function main() {
         });
     }
     console.log('Parcelas criadas');
+    // -------------------------------
+    // EMAILS ENVIADOS
+    // -------------------------------
+
+    const emails = [
+        {
+            id: 1,
+            nomeUsuario: 'João Silva',
+            emailUsuario: 'joao.silva@email.com',
+            assunto: 'Dúvida sobre IPVA',
+            textoDigitado: 'Gostaria de saber as datas de vencimento do IPVA para o meu veículo.',
+            dataEnvio: new Date('2026-01-15T10:30:00'),
+        },
+        {
+            id: 2,
+            nomeUsuario: 'Maria Souza',
+            emailUsuario: 'maria.souza@email.com',
+            assunto: 'Recurso de multa',
+            textoDigitado: 'Preciso de ajuda para entender como recorrer de uma multa que recebi.',
+            dataEnvio: new Date('2026-01-20T14:00:00'),
+        },
+    ];
+
+    for (const email of emails) {
+        await prisma.emailsEnviados.upsert({
+            where: { id: email.id },
+            update: {
+                nomeUsuario: email.nomeUsuario,
+                emailUsuario: email.emailUsuario,
+                assunto: email.assunto,
+                textoDigitado: email.textoDigitado,
+            },
+            create: email,
+        });
+    }
+
+    console.log('Emails enviados criados');
 
     console.log('Seed concluído com sucesso!');
 }


### PR DESCRIPTION
Corrige os steps de CI para melhor aplicar as migrations sem chance de erro por causa do comando de `generate`, e consolida correções de consistência no schema do Prisma e no script de seed.

## Alterações

### CI / GitHub Actions
- Reordena os steps nos workflows `migrate-dev.yml` e `migrate-prod.yml`: `prisma migrate deploy` agora roda **antes** de `prisma generate`.
- Adiciona a env `DATABASE_URL` ao step `prisma generate` em ambos os workflows.
- Padroniza a interpolação de secrets para `${{ secrets.* }}` (com espaços).

### Docker Compose
- Atualiza a imagem do serviço `migration` no `compose.dev.yml` de `node:20-alpine` para `node:22-alpine`.

### Schema do Prisma (`schema.prisma`)
- Renomeia o model `emails_enviados` para `EmailsEnviados`, adotando PascalCase conforme convenção dos demais models.
- Converte os campos snake_case (`nome_usuario`, `email_usuario`, `texto_digitado`, `data_envio`) para camelCase com `@map`, mantendo compatibilidade com o banco.
- Corrige alinhamento e formatação no model `Blog`.

### Seed (`seed.ts`)
- Adiciona seed para o model `EmailsEnviados`.
- Melhora o tratamento de conexão: valida a presença de `DATABASE_URL` antes de inicializar e usa `URL` nativo para trocar o protocolo `mysql:` → `mariadb:`.
- Torna os upserts do model `Blog` idempotentes, incluindo todos os campos no bloco `update`.
- Adiciona o campo `ativo` explicitamente nos registros de seed do `Blog`.

### Documentação
- Melhora a nota sobre o `compose.dev.yml` no `README.md`.