### PR TITLE
feat: adiciona campo exige_veiculo na tabela servico e atualiza seed

### DIFF
--- a/documentacao/docs/assets/diagrama_banco.md
+++ b/documentacao/docs/assets/diagrama_banco.md
@@ -82,6 +82,7 @@ erDiagram
         decimal valor_base
         int prazo_estimado_dias
         bool ativo
+        bool exige_veiculo
     }
     DocumentoSolicitacao {
         int id PK

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "mariadb": "^3.5.2"
       },
       "devDependencies": {
-        "@types/node": "^25.3.3",
+        "@types/node": "^25.6.0",
         "dotenv": "^17.3.1",
         "prisma": "^7.4.2",
         "tsx": "^4.21.0",
@@ -962,12 +962,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
-      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/react": {
@@ -1943,9 +1943,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/valibot": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/laboratorio-de-praticas-2026-1/database#readme",
   "devDependencies": {
-    "@types/node": "^25.3.3",
+    "@types/node": "^25.6.0",
     "dotenv": "^17.3.1",
     "prisma": "^7.4.2",
     "tsx": "^4.21.0",

--- a/prisma/migrations/20260410213519_add_exige_veiculo_em_servico/migration.sql
+++ b/prisma/migrations/20260410213519_add_exige_veiculo_em_servico/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `servico` ADD COLUMN `exige_veiculo` BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -150,6 +150,7 @@ model Servico {
   valorBase         Decimal? @map("valor_base") @db.Decimal(10, 2)
   prazoEstimadoDias Int?     @map("prazo_estimado_dias")
   ativo             Boolean  @default(true)
+  exigeVeiculo      Boolean  @default(true) @map("exige_veiculo")
 
   solicitacoes   Solicitacao[]
   debitoServicos DebitoServico[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -158,7 +158,8 @@ async function main() {
             descricao: 'Renovação do CRLV anual',
             valorBase: 180.00,
             prazoEstimadoDias: 2,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: true
         },
         {
             id: 2,
@@ -166,7 +167,8 @@ async function main() {
             descricao: 'Transferência de titularidade do veículo',
             valorBase: 350.00,
             prazoEstimadoDias: 5,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: true
         },
         {
             id: 3,
@@ -174,7 +176,8 @@ async function main() {
             descricao: 'Registro de veículo zero quilômetro',
             valorBase: 420.00,
             prazoEstimadoDias: 7,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: true
         },
         {
             id: 4,
@@ -182,7 +185,8 @@ async function main() {
             descricao: 'Renovação da carteira de habilitação',
             valorBase: 200.00,
             prazoEstimadoDias: 10,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: false
         },
         {
             id: 5,
@@ -190,7 +194,8 @@ async function main() {
             descricao: 'Retirada de restrição financeira do veículo',
             valorBase: 190.00,
             prazoEstimadoDias: 3,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: true
         },
         {
             id: 6,
@@ -198,7 +203,8 @@ async function main() {
             descricao: 'Defesa administrativa de autuação',
             valorBase: 250.00,
             prazoEstimadoDias: 15,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: true
         },
         {
             id: 7,
@@ -206,7 +212,8 @@ async function main() {
             descricao: 'Emissão de segunda via do documento',
             valorBase: 120.00,
             prazoEstimadoDias: 2,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: true
         },
         {
             id: 8,
@@ -214,7 +221,8 @@ async function main() {
             descricao: 'Alteração de categoria da habilitação',
             valorBase: 600.00,
             prazoEstimadoDias: 30,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: false
         },
         {
             id: 9,
@@ -222,7 +230,8 @@ async function main() {
             descricao: 'Registro de venda no Detran',
             valorBase: 150.00,
             prazoEstimadoDias: 1,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: true
         },
         {
             id: 10,
@@ -230,9 +239,11 @@ async function main() {
             descricao: 'Parcelamento de IPVA e multas pendentes',
             valorBase: 90.00,
             prazoEstimadoDias: 1,
-            ativo: true
+            ativo: true,
+            exigeVeiculo: true
         },
     ];
+
     for (const s of servicos) {
         await prisma.servico.upsert({
             where: {id: s.id},
@@ -240,12 +251,15 @@ async function main() {
                 nome: s.nome,
                 descricao: s.descricao,
                 valorBase: s.valorBase,
-                prazoEstimadoDias: s.prazoEstimadoDias
+                prazoEstimadoDias: s.prazoEstimadoDias,
+                ativo: s.ativo,
+                exigeVeiculo: s.exigeVeiculo
             },
             create: s,
         });
     }
     console.log('Serviços criados');
+    
 
     // Banners
     const banners = [


### PR DESCRIPTION
**Descrição**
Esta alteração adiciona o campo booleano exige_veiculo na tabela servico, com o objetivo de indicar se um serviço exige ou não a vinculação obrigatória de um veículo no momento da criação da solicitação.

Nem todos os serviços necessitam de um veículo associado (ex.: Renovação de CNH). Com esse campo, a aplicação poderá decidir dinamicamente se o formulário deve solicitar ou não as informações do veículo.

**Alterações realizadas**
- Adição do campo exige_veiculo (Boolean) na tabela servico
- Atualização do schema.prisma
- Criação da migration add_exige_veiculo_em_servico
- Atualização do arquivo seed.ts com valores adequados para os serviços
- Ajuste da lógica de upsert na seed para incluir o novo campo